### PR TITLE
Fix the Black Chair Bug

### DIFF
--- a/Reticle/Reticle.depend
+++ b/Reticle/Reticle.depend
@@ -1776,7 +1776,7 @@
 	<Core/RetiSpinlock.h>
 	<Math/RetiTransform.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/dummy.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/dummy.cpp
 	<glm/glm.hpp>
 	<glm/ext.hpp>
 	<limits>
@@ -1796,7 +1796,7 @@
 	<glm/exponential.hpp>
 	<glm/gtc/random.hpp>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/glm.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/glm.hpp
 	"detail/_fixes.hpp"
 	<cmath>
 	<climits>
@@ -1825,26 +1825,26 @@
 	"vector_relational.hpp"
 	"integer.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_fixes.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_fixes.hpp
 	<cmath>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/fwd.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/fwd.hpp
 	"detail/type_int.hpp"
 	"detail/type_float.hpp"
 	"detail/type_vec.hpp"
 	"detail/type_mat.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_int.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_int.hpp
 	"setup.hpp"
 	<type_traits>
 	<cstdint>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/setup.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/setup.hpp
 	<cassert>
 	<cstddef>
 	"../simd/platform.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/platform.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/platform.h
 	<cuda.h>
 	<intrin.h>
 	<immintrin.h>
@@ -1856,66 +1856,66 @@
 	<pmmintrin.h>
 	<emmintrin.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_float.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_float.hpp
 	"setup.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec.hpp
 	"precision.hpp"
 	"type_int.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/precision.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/precision.hpp
 	"setup.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat.hpp
 	"precision.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec2.hpp
 	"detail/type_vec2.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec2.hpp
 	"type_vec.hpp"
 	"_swizzle.hpp"
 	"_swizzle_func.hpp"
 	<cstddef>
 	"type_vec2.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_swizzle.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_swizzle.hpp
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_swizzle_func.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_swizzle_func.hpp
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec2.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec2.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec3.hpp
 	"detail/type_vec3.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec3.hpp
 	"type_vec.hpp"
 	"_swizzle.hpp"
 	"_swizzle_func.hpp"
 	<cstddef>
 	"type_vec3.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec3.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec3.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vec4.hpp
 	"detail/type_vec4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4.hpp
 	"type_vec.hpp"
 	"_swizzle.hpp"
 	"_swizzle_func.hpp"
 	<cstddef>
 	"type_vec4.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4.inl
 	"type_vec4_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec4_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x2.hpp
 	"detail/type_mat2x2.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x2.hpp
 	"../fwd.hpp"
 	"type_vec2.hpp"
 	"type_mat.hpp"
@@ -1923,10 +1923,10 @@
 	<cstddef>
 	"type_mat2x2.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x2.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x2.inl
 	"func_matrix.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix.hpp
 	"../detail/precision.hpp"
 	"../detail/setup.hpp"
 	"../detail/type_mat.hpp"
@@ -1944,10 +1944,10 @@
 	"../mat4x4.hpp"
 	"func_matrix.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x3.hpp
 	"detail/type_mat2x3.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x3.hpp
 	"../fwd.hpp"
 	"type_vec2.hpp"
 	"type_vec3.hpp"
@@ -1956,12 +1956,12 @@
 	<cstddef>
 	"type_mat2x3.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x3.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x3.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat2x4.hpp
 	"detail/type_mat2x4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x4.hpp
 	"../fwd.hpp"
 	"type_vec2.hpp"
 	"type_vec4.hpp"
@@ -1970,12 +1970,12 @@
 	<cstddef>
 	"type_mat2x4.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x4.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat2x4.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x2.hpp
 	"detail/type_mat3x2.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x2.hpp
 	"../fwd.hpp"
 	"type_vec2.hpp"
 	"type_vec3.hpp"
@@ -1984,12 +1984,12 @@
 	<cstddef>
 	"type_mat3x2.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x2.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x2.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x3.hpp
 	"detail/type_mat3x3.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x3.hpp
 	"../fwd.hpp"
 	"type_vec3.hpp"
 	"type_mat.hpp"
@@ -1997,13 +1997,13 @@
 	<cstddef>
 	"type_mat3x3.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x3.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x3.inl
 	"func_matrix.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat3x4.hpp
 	"detail/type_mat3x4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x4.hpp
 	"../fwd.hpp"
 	"type_vec3.hpp"
 	"type_vec4.hpp"
@@ -2012,12 +2012,12 @@
 	<cstddef>
 	"type_mat3x4.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x4.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat3x4.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x2.hpp
 	"detail/type_mat4x2.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x2.hpp
 	"../fwd.hpp"
 	"type_vec2.hpp"
 	"type_vec4.hpp"
@@ -2026,12 +2026,12 @@
 	<cstddef>
 	"type_mat4x2.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x2.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x2.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x3.hpp
 	"detail/type_mat4x3.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x3.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x3.hpp
 	"../fwd.hpp"
 	"type_vec3.hpp"
 	"type_vec4.hpp"
@@ -2040,12 +2040,12 @@
 	<cstddef>
 	"type_mat4x3.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x3.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x3.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/mat4x4.hpp
 	"detail/type_mat4x4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4.hpp
 	"../fwd.hpp"
 	"type_vec4.hpp"
 	"type_mat.hpp"
@@ -2053,25 +2053,25 @@
 	<cstddef>
 	"type_mat4x4.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4.inl
 	"func_matrix.hpp"
 	"type_mat4x4_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_mat4x4_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix.inl
 	"../geometric.hpp"
 	<limits>
 	"func_matrix_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/geometric.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/geometric.hpp
 	"detail/func_geometric.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric.hpp
 	"type_vec3.hpp"
 	"func_geometric.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric.inl
 	"func_exponential.hpp"
 	"func_common.hpp"
 	"type_vec2.hpp"
@@ -2079,7 +2079,7 @@
 	"type_float.hpp"
 	"func_geometric_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential.hpp
 	"type_vec1.hpp"
 	"type_vec2.hpp"
 	"type_vec3.hpp"
@@ -2087,7 +2087,7 @@
 	<cmath>
 	"func_exponential.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec1.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec1.hpp
 	"../fwd.hpp"
 	"type_vec.hpp"
 	"_swizzle.hpp"
@@ -2095,9 +2095,9 @@
 	<cstddef>
 	"type_vec1.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec1.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_vec1.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential.inl
 	"func_vector_relational.hpp"
 	"_vectorize.hpp"
 	<limits>
@@ -2105,37 +2105,37 @@
 	<cassert>
 	"func_exponential_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational.hpp
 	"precision.hpp"
 	"setup.hpp"
 	"func_vector_relational.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational.inl
 	<limits>
 	"func_vector_relational_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_vector_relational_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_vectorize.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_vectorize.hpp
 	"type_vec1.hpp"
 	"type_vec2.hpp"
 	"type_vec3.hpp"
 	"type_vec4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_exponential_simd.inl
 	"../simd/exponential.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/exponential.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/exponential.h
 	"platform.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common.hpp
 	"setup.hpp"
 	"precision.hpp"
 	"type_int.hpp"
 	"_fixes.hpp"
 	"func_common.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common.inl
 	"func_vector_relational.hpp"
 	"type_vec2.hpp"
 	"type_vec3.hpp"
@@ -2144,88 +2144,88 @@
 	<limits>
 	"func_common_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_common_simd.inl
 	"../simd/common.h"
 	<immintrin.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/common.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/common.h
 	"platform.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_geometric_simd.inl
 	"../simd/geometric.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/geometric.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/geometric.h
 	"common.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_matrix_simd.inl
 	"type_mat4x4.hpp"
 	"func_geometric.hpp"
 	"../simd/matrix.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/matrix.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/matrix.h
 	"geometric.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/trigonometric.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/trigonometric.hpp
 	"detail/func_trigonometric.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric.hpp
 	"setup.hpp"
 	"precision.hpp"
 	"func_trigonometric.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric.inl
 	"_vectorize.hpp"
 	<cmath>
 	<limits>
 	"func_trigonometric_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_trigonometric_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/exponential.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/exponential.hpp
 	"detail/func_exponential.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/common.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/common.hpp
 	"detail/func_common.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/packing.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/packing.hpp
 	"detail/func_packing.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing.hpp
 	"type_vec2.hpp"
 	"type_vec4.hpp"
 	"func_packing.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing.inl
 	"func_common.hpp"
 	"type_half.hpp"
 	"../fwd.hpp"
 	"func_packing_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_half.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_half.hpp
 	"setup.hpp"
 	"type_half.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_half.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/type_half.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_packing_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/matrix.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/matrix.hpp
 	"detail/func_matrix.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vector_relational.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/vector_relational.hpp
 	"detail/func_vector_relational.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/integer.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/integer.hpp
 	"detail/func_integer.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer.hpp
 	"setup.hpp"
 	"precision.hpp"
 	"func_common.hpp"
 	"func_vector_relational.hpp"
 	"func_integer.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer.inl
 	"type_vec2.hpp"
 	"type_vec3.hpp"
 	"type_vec4.hpp"
@@ -2235,12 +2235,12 @@
 	<limits>
 	"func_integer_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/func_integer_simd.inl
 	"../simd/integer.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/integer.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/simd/integer.h
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/ext.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/ext.hpp
 	"glm.hpp"
 	"./gtc/bitfield.hpp"
 	"./gtc/color_space.hpp"
@@ -2311,7 +2311,7 @@
 	"./gtx/scalar_multiplication.hpp"
 	"./gtx/range.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/bitfield.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/bitfield.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/type_int.hpp"
@@ -2319,10 +2319,10 @@
 	<limits>
 	"bitfield.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/bitfield.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/bitfield.inl
 	"../simd/integer.h"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/color_space.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/color_space.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../exponential.hpp"
@@ -2331,21 +2331,21 @@
 	<limits>
 	"color_space.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/color_space.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/color_space.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/constants.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/constants.hpp
 	"../detail/setup.hpp"
 	"constants.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/constants.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/constants.inl
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/epsilon.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/epsilon.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"epsilon.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/epsilon.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/epsilon.inl
 	"quaternion.hpp"
 	"../vector_relational.hpp"
 	"../common.hpp"
@@ -2353,7 +2353,7 @@
 	"../vec3.hpp"
 	"../vec4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion.hpp
 	"../mat3x3.hpp"
 	"../mat4x4.hpp"
 	"../vec3.hpp"
@@ -2361,25 +2361,25 @@
 	"../gtc/constants.hpp"
 	"quaternion.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion.inl
 	"../trigonometric.hpp"
 	"../geometric.hpp"
 	"../exponential.hpp"
 	<limits>
 	"quaternion_simd.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion_simd.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/quaternion_simd.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/functions.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/functions.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/type_vec2.hpp"
 	"functions.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/functions.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/functions.inl
 	"../detail/func_exponential.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/integer.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/integer.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/func_common.hpp"
@@ -2388,15 +2388,15 @@
 	<limits>
 	"integer.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/integer.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/integer.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_access.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_access.hpp
 	"../detail/setup.hpp"
 	"matrix_access.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_access.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_access.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_integer.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_integer.hpp
 	"../mat2x2.hpp"
 	"../mat2x3.hpp"
 	"../mat2x4.hpp"
@@ -2407,7 +2407,7 @@
 	"../mat4x3.hpp"
 	"../mat4x4.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_inverse.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_inverse.hpp
 	"../detail/setup.hpp"
 	"../matrix.hpp"
 	"../mat2x2.hpp"
@@ -2415,9 +2415,9 @@
 	"../mat4x4.hpp"
 	"matrix_inverse.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_inverse.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_inverse.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_transform.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_transform.hpp
 	"../mat4x4.hpp"
 	"../vec2.hpp"
 	"../vec3.hpp"
@@ -2425,12 +2425,12 @@
 	"../gtc/constants.hpp"
 	"matrix_transform.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_transform.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/matrix_transform.inl
 	"../geometric.hpp"
 	"../trigonometric.hpp"
 	"../matrix.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/noise.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/noise.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/_noise.hpp"
@@ -2442,19 +2442,19 @@
 	"../vec4.hpp"
 	"noise.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_noise.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/_noise.hpp
 	"../vec2.hpp"
 	"../vec3.hpp"
 	"../vec4.hpp"
 	"../common.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/noise.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/noise.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/packing.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/packing.hpp
 	"type_precision.hpp"
 	"packing.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_precision.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_precision.hpp
 	"../gtc/quaternion.hpp"
 	"../gtc/vec1.hpp"
 	"../vec2.hpp"
@@ -2471,16 +2471,16 @@
 	"../mat4x4.hpp"
 	"type_precision.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/vec1.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/vec1.hpp
 	"../glm.hpp"
 	"../detail/type_vec1.hpp"
 	"vec1.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/vec1.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/vec1.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_precision.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_precision.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/packing.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/packing.inl
 	"../common.hpp"
 	"../vec2.hpp"
 	"../vec3.hpp"
@@ -2489,27 +2489,27 @@
 	<cstring>
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/random.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/random.hpp
 	"../vec2.hpp"
 	"../vec3.hpp"
 	"random.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/random.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/random.inl
 	"../geometric.hpp"
 	"../exponential.hpp"
 	<cstdlib>
 	<ctime>
 	<cassert>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/reciprocal.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/reciprocal.hpp
 	"../detail/setup.hpp"
 	"reciprocal.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/reciprocal.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/reciprocal.inl
 	"../trigonometric.hpp"
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/round.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/round.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/_vectorize.hpp"
@@ -2518,10 +2518,10 @@
 	<limits>
 	"round.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/round.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/round.inl
 	"../detail/func_integer.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_ptr.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_ptr.hpp
 	"../gtc/quaternion.hpp"
 	"../vec2.hpp"
 	"../vec3.hpp"
@@ -2538,151 +2538,151 @@
 	<cstring>
 	"type_ptr.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_ptr.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_ptr.inl
 	<cstring>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/ulp.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/ulp.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"../detail/type_int.hpp"
 	"ulp.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/ulp.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/ulp.inl
 	"../detail/type_int.hpp"
 	<cmath>
 	<cfloat>
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_aligned.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtc/type_aligned.hpp
 	"../vec2.hpp"
 	"../vec3.hpp"
 	"../vec4.hpp"
 	"../gtc/vec1.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/associated_min_max.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/associated_min_max.hpp
 	"../glm.hpp"
 	"associated_min_max.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/associated_min_max.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/associated_min_max.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/bit.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/bit.hpp
 	"../gtc/bitfield.hpp"
 	"bit.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/bit.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/bit.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/closest_point.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/closest_point.hpp
 	"../glm.hpp"
 	"closest_point.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/closest_point.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/closest_point.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space.hpp
 	"../glm.hpp"
 	"color_space.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space_YCoCg.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space_YCoCg.hpp
 	"../glm.hpp"
 	"color_space_YCoCg.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space_YCoCg.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/color_space_YCoCg.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/compatibility.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/compatibility.hpp
 	"../glm.hpp"
 	"../gtc/quaternion.hpp"
 	<cfloat>
 	<cmath>
 	"compatibility.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/compatibility.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/compatibility.inl
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/component_wise.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/component_wise.hpp
 	"../detail/setup.hpp"
 	"../detail/precision.hpp"
 	"component_wise.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/component_wise.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/component_wise.inl
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/dual_quaternion.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/dual_quaternion.hpp
 	"../glm.hpp"
 	"../gtc/constants.hpp"
 	"../gtc/quaternion.hpp"
 	"dual_quaternion.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/dual_quaternion.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/dual_quaternion.inl
 	"../geometric.hpp"
 	<limits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/euler_angles.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/euler_angles.hpp
 	"../glm.hpp"
 	"euler_angles.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/euler_angles.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/euler_angles.inl
 	"compatibility.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extend.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extend.hpp
 	"../glm.hpp"
 	"extend.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extend.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extend.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extended_min_max.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extended_min_max.hpp
 	"../glm.hpp"
 	"extended_min_max.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extended_min_max.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/extended_min_max.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_exponential.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_exponential.hpp
 	"../glm.hpp"
 	"fast_exponential.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_exponential.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_exponential.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_square_root.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_square_root.hpp
 	"../common.hpp"
 	"../exponential.hpp"
 	"../geometric.hpp"
 	"fast_square_root.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_square_root.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_square_root.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_trigonometry.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_trigonometry.hpp
 	"../gtc/constants.hpp"
 	"fast_trigonometry.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_trigonometry.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/fast_trigonometry.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/gradient_paint.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/gradient_paint.hpp
 	"../glm.hpp"
 	"../gtx/optimum_pow.hpp"
 	"gradient_paint.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/optimum_pow.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/optimum_pow.hpp
 	"../glm.hpp"
 	"optimum_pow.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/optimum_pow.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/optimum_pow.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/gradient_paint.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/gradient_paint.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/handed_coordinate_space.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/handed_coordinate_space.hpp
 	"../glm.hpp"
 	"handed_coordinate_space.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/handed_coordinate_space.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/handed_coordinate_space.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/integer.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/integer.hpp
 	"../glm.hpp"
 	"../gtc/integer.hpp"
 	"integer.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/integer.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/integer.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/intersect.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/intersect.hpp
 	<cfloat>
 	<limits>
 	"../glm.hpp"
@@ -2691,162 +2691,162 @@
 	"../gtx/vector_query.hpp"
 	"intersect.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_query.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_query.hpp
 	"../glm.hpp"
 	<cfloat>
 	<limits>
 	"vector_query.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_query.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_query.inl
 	<cassert>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/intersect.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/intersect.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/log_base.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/log_base.hpp
 	"../glm.hpp"
 	"log_base.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/log_base.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/log_base.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_cross_product.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_cross_product.hpp
 	"../glm.hpp"
 	"matrix_cross_product.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_cross_product.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_cross_product.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_interpolation.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_interpolation.hpp
 	"../glm.hpp"
 	"matrix_interpolation.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_interpolation.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_interpolation.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_major_storage.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_major_storage.hpp
 	"../glm.hpp"
 	"matrix_major_storage.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_major_storage.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_major_storage.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_operation.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_operation.hpp
 	"../glm.hpp"
 	"matrix_operation.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_operation.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_operation.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_query.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_query.hpp
 	"../glm.hpp"
 	"../gtx/vector_query.hpp"
 	<limits>
 	"matrix_query.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_query.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/matrix_query.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/mixed_product.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/mixed_product.hpp
 	"../glm.hpp"
 	"mixed_product.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/mixed_product.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/mixed_product.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/norm.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/norm.hpp
 	"../detail/func_geometric.hpp"
 	"../gtx/quaternion.hpp"
 	"norm.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/quaternion.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/quaternion.hpp
 	"../glm.hpp"
 	"../gtc/constants.hpp"
 	"../gtc/quaternion.hpp"
 	"../gtx/norm.hpp"
 	"quaternion.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/quaternion.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/quaternion.inl
 	<limits>
 	"../gtc/constants.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/norm.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/norm.inl
 	"../detail/precision.hpp"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normal.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normal.hpp
 	"../glm.hpp"
 	"normal.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normal.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normal.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normalize_dot.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normalize_dot.hpp
 	"../gtx/fast_square_root.hpp"
 	"normalize_dot.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normalize_dot.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/normalize_dot.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/number_precision.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/number_precision.hpp
 	"../glm.hpp"
 	"../gtc/type_precision.hpp"
 	"number_precision.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/number_precision.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/number_precision.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/orthonormalize.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/orthonormalize.hpp
 	"../vec3.hpp"
 	"../mat3x3.hpp"
 	"../geometric.hpp"
 	"orthonormalize.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/orthonormalize.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/orthonormalize.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/perpendicular.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/perpendicular.hpp
 	"../glm.hpp"
 	"../gtx/projection.hpp"
 	"perpendicular.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/projection.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/projection.hpp
 	"../geometric.hpp"
 	"projection.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/projection.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/projection.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/perpendicular.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/perpendicular.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/polar_coordinates.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/polar_coordinates.hpp
 	"../glm.hpp"
 	"polar_coordinates.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/polar_coordinates.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/polar_coordinates.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/raw_data.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/raw_data.hpp
 	"../detail/setup.hpp"
 	"../detail/type_int.hpp"
 	"raw_data.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/raw_data.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/raw_data.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/rotate_vector.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/rotate_vector.hpp
 	"../glm.hpp"
 	"../gtx/transform.hpp"
 	"rotate_vector.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform.hpp
 	"../glm.hpp"
 	"../gtc/matrix_transform.hpp"
 	"transform.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/rotate_vector.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/rotate_vector.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/spline.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/spline.hpp
 	"../glm.hpp"
 	"../gtx/optimum_pow.hpp"
 	"spline.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/spline.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/spline.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/std_based_type.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/std_based_type.hpp
 	"../glm.hpp"
 	<cstdlib>
 	"std_based_type.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/std_based_type.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/std_based_type.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/string_cast.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/string_cast.hpp
 	"../glm.hpp"
 	"../gtc/type_precision.hpp"
 	"../gtc/quaternion.hpp"
@@ -2854,34 +2854,34 @@
 	<string>
 	"string_cast.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/string_cast.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/string_cast.inl
 	<cstdarg>
 	<cstdio>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform2.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform2.hpp
 	"../glm.hpp"
 	"../gtx/transform.hpp"
 	"transform2.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform2.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/transform2.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_angle.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_angle.hpp
 	"../glm.hpp"
 	"../gtc/epsilon.hpp"
 	"../gtx/quaternion.hpp"
 	"../gtx/rotate_vector.hpp"
 	"vector_angle.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_angle.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/vector_angle.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/wrap.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/wrap.hpp
 	"../glm.hpp"
 	"../gtc/vec1.hpp"
 	"wrap.inl"
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/wrap.inl
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/wrap.inl
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/scalar_multiplication.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/scalar_multiplication.hpp
 	"../detail/setup.hpp"
 	"../vec2.hpp"
 	"../vec3.hpp"
@@ -2889,32 +2889,32 @@
 	"../mat2x2.hpp"
 	<type_traits>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/range.hpp
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/gtx/range.hpp
 	"../detail/setup.hpp"
 	"../gtc/type_ptr.hpp"
 	"../gtc/vec1.hpp"
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/glm.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Includes/glm/detail/glm.cpp
 	<glm/glm.hpp>
 	<glm/gtc/quaternion.hpp>
 	<glm/gtx/dual_quaternion.hpp>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Core/RetiLog.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Core/RetiLog.cpp
 	<ctime>
 	<Core/RetiLog.h>
 	<RetiRenderer.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Core/RetiLog.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Core/RetiLog.h
 	<iostream>
 	<fstream>
 	<Core/RetiSpinlock.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Core/RetiSpinlock.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Core/RetiSpinlock.h
 	<thread>
 	<atomic>
 	<pthread.h>
 
-1500138134 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiRenderer.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiRenderer.h
 	<vector>
 	<string>
 	<iostream>
@@ -2924,14 +2924,14 @@
 	<atomic>
 	<includes.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/includes.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/includes.h
 	<GL/glew.h>
 	<GLFW/glfw3.h>
 	<glm/glm.hpp>
 	<glm/gtc/matrix_transform.hpp>
 	<glm/gtc/type_ptr.hpp>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/GL/glew.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/GL/glew.h
 	<stddef.h>
 	<inttypes.h>
 	<stdint.h>
@@ -2940,7 +2940,7 @@
 	<OpenGL/glu.h>
 	<GL/glu.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/GLFW/glfw3.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Includes/GLFW/glfw3.h
 	<stddef.h>
 	<stdint.h>
 	<OpenGL/gl3.h>
@@ -2961,28 +2961,31 @@
 	<GL/glext.h>
 	<GL/glu.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Core/RetiSpinlock.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Core/RetiSpinlock.cpp
 	<Core/RetiSpinlock.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Math/RetiTransform.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/Math/RetiTransform.cpp
+	<string>
 	<includes.h>
 	<Math/RetiTransform.h>
+	<Core/RetiLog.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Math/RetiTransform.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/Math/RetiTransform.h
+	<map>
 	<includes.h>
 	<Core/RetiSpinlock.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiCamera.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiCamera.cpp
 	<includes.h>
 	<RetiCamera.h>
 	<Math/RetiTransform.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiCamera.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiCamera.h
 	<includes.h>
 	<Core/RetiSpinlock.h>
 	<Math/RetiTransform.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiMaterial.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiMaterial.cpp
 	<includes.h>
 	<fstream>
 	<RetiMaterial.h>
@@ -2991,22 +2994,22 @@
 	<RetiRenderer.h>
 	<Core/RetiLog.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiMaterial.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiMaterial.h
 	<vector>
 	<unordered_map>
 	<string>
 	<includes.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiTexture.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiTexture.h
 	<string>
 	<unordered_map>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiShader.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiShader.h
 	<includes.h>
 	<string>
 	<includes.h>
 
-1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiMesh.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiMesh.cpp
 	<includes.h>
 	<iostream>
 	<RetiMesh.h>
@@ -3017,17 +3020,18 @@
 	<Core/RetiSpinlock.h>
 	<Math/RetiTransform.h>
 
-1499860113 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiMesh.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiMesh.h
 	<includes.h>
 	<vector>
 	<RetiMaterial.h>
 	<Core/RetiSpinlock.h>
 	<Math/RetiTransform.h>
 
-1500138240 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiRenderer.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiRenderer.cpp
 	<includes.h>
 	<iostream>
 	<ctime>
+	<chrono>
 	<cstring>
 	<fstream>
 	<functional>
@@ -3038,6 +3042,7 @@
 	<RetiTexture.h>
 	<RetiCamera.h>
 	<RetiKeyboard.h>
+	<RetiSceneObject.h>
 	<Core/RetiLog.h>
 
 1499860113 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiTexture.cpp
@@ -3064,7 +3069,7 @@
 	<intrin.h>
 	<arm_neon.h>
 
-1500053810 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiShader.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiShader.cpp
 	<includes.h>
 	<iostream>
 	<fstream>
@@ -3074,10 +3079,11 @@
 	<RetiRenderer.h>
 	<Core/RetiLog.h>
 
-1500118656 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiKeyboard.cpp
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiKeyboard.cpp
 	<RetiKeyboard.h>
+	<Core/RetiLog.h>
 
-1500137997 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiKeyboard.h
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiKeyboard.h
 	<map>
 	<includes.h>
 	<Core/RetiSpinlock.h>
@@ -5741,4 +5747,22 @@
 	<includes.h>
 	<RetiCamera.h>
 	<Math/RetiTransform.h>
+
+1500832463 /mnt/data/git-repos/ProjectReticle/Reticle/Headers/RetiSceneObject.h
+	<vector>
+	<string>
+	<includes.h>
+	<assimp/Importer.hpp>
+	<assimp/scene.h>
+	<assimp/postprocess.h>
+	<Math/RetiTransform.h>
+
+1500832463 source:/mnt/data/git-repos/ProjectReticle/Reticle/Sources/RetiSceneObject.cpp
+	<cmath>
+	<includes.h>
+	<RetiSceneObject.h>
+	<RetiMesh.h>
+	<RetiMaterial.h>
+	<RetiTexture.h>
+	<Core/RetiLog.h>
 

--- a/Reticle/Reticle.layout
+++ b/Reticle/Reticle.layout
@@ -2,34 +2,14 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Debug" />
-	<File name="Sources/RetiSceneObject.cpp" open="1" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Headers/RetiCamera.h" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="8567" topLine="229" />
+			<Cursor1 position="567" topLine="8" />
 		</Cursor>
 	</File>
-	<File name="Sources/RetiShader.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Sources/RetiMaterial.cpp" open="0" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="3987" topLine="120" />
-		</Cursor>
-	</File>
-	<File name="Shaders/Default_v.shdr" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="199" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Shaders/Default_f.shdr" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="110" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Sources/RetiMesh.cpp" open="1" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4187" topLine="108" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiTexture.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1242" topLine="59" />
+			<Cursor1 position="4521" topLine="138" />
 		</Cursor>
 	</File>
 	<File name="Sources/RetiCamera.cpp" open="0" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -37,89 +17,9 @@
 			<Cursor1 position="991" topLine="35" />
 		</Cursor>
 	</File>
-	<File name="Headers/RetiSceneObject.h" open="1" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2497" topLine="53" />
-		</Cursor>
-	</File>
-	<File name="Sources/Core/RetiLog.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="206" topLine="14" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiCamera.h" open="1" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="567" topLine="8" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiRenderer.h" open="1" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1852" topLine="58" />
-		</Cursor>
-	</File>
-	<File name="Sources/RetiKeyboard.cpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1311" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="Headers/Math/RetiTransform.h" open="1" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1239" topLine="15" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiMesh.h" open="1" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2523" topLine="29" />
-		</Cursor>
-	</File>
-	<File name="Headers/reticle.h" open="1" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Headers/reticle.h" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="278" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiShader.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="365" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Sources/RetiRenderer.cpp" open="1" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="910" topLine="27" />
-		</Cursor>
-	</File>
-	<File name="Sources/RetiMaterial.cpp" open="1" top="0" tabpos="16" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="4521" topLine="138" />
-		</Cursor>
-	</File>
-	<File name="Headers/includes.h" open="1" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="450" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Headers/Core/RetiLog.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="431" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Includes/stb_image.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="29396" topLine="825" />
-		</Cursor>
-	</File>
-	<File name="Sources/Core/RetiSpinlock.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="138" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="Sources/Math/RetiTransform.cpp" open="1" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="3051" topLine="88" />
-		</Cursor>
-	</File>
-	<File name="Headers/RetiMaterial.h" open="1" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="2112" topLine="29" />
 		</Cursor>
 	</File>
 	<File name="Headers/Core/RetiSpinlock.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -127,19 +27,119 @@
 			<Cursor1 position="256" topLine="0" />
 		</Cursor>
 	</File>
+	<File name="Sources/RetiKeyboard.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1311" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="Sources/RetiSceneObject.cpp" open="0" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="8567" topLine="229" />
+		</Cursor>
+	</File>
+	<File name="Headers/RetiSceneObject.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2497" topLine="53" />
+		</Cursor>
+	</File>
+	<File name="Includes/stb_image.h" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="29396" topLine="825" />
+		</Cursor>
+	</File>
+	<File name="Headers/Core/RetiLog.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="431" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Sources/Core/RetiSpinlock.cpp" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="138" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Headers/RetiTexture.h" open="0" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1242" topLine="59" />
+		</Cursor>
+	</File>
+	<File name="Sources/RetiTexture.cpp" open="1" top="1" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1982" topLine="81" />
+		</Cursor>
+	</File>
+	<File name="Headers/RetiKeyboard.h" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3845" topLine="51" />
+		</Cursor>
+	</File>
+	<File name="Headers/includes.h" open="0" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="450" topLine="0" />
+		</Cursor>
+	</File>
 	<File name="Shaders/Default.shif" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="44" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="Headers/RetiKeyboard.h" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Headers/RetiMesh.h" open="0" top="0" tabpos="13" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="3845" topLine="51" />
+			<Cursor1 position="2523" topLine="29" />
 		</Cursor>
 	</File>
-	<File name="Sources/RetiTexture.cpp" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="Headers/RetiShader.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="95" topLine="0" />
+			<Cursor1 position="365" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Headers/RetiMaterial.h" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="2112" topLine="29" />
+		</Cursor>
+	</File>
+	<File name="Shaders/Default_f.shdr" open="0" top="0" tabpos="15" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="110" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Shaders/Default_v.shdr" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="199" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="Headers/RetiRenderer.h" open="0" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1852" topLine="58" />
+		</Cursor>
+	</File>
+	<File name="Sources/RetiMesh.cpp" open="0" top="0" tabpos="14" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="4187" topLine="108" />
+		</Cursor>
+	</File>
+	<File name="Headers/Math/RetiTransform.h" open="0" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1239" topLine="15" />
+		</Cursor>
+	</File>
+	<File name="Sources/Core/RetiLog.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="206" topLine="14" />
+		</Cursor>
+	</File>
+	<File name="Sources/RetiShader.cpp" open="0" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3987" topLine="120" />
+		</Cursor>
+	</File>
+	<File name="Sources/RetiRenderer.cpp" open="0" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="910" topLine="27" />
+		</Cursor>
+	</File>
+	<File name="Sources/Math/RetiTransform.cpp" open="0" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="3051" topLine="88" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/Reticle/Sources/RetiTexture.cpp
+++ b/Reticle/Sources/RetiTexture.cpp
@@ -53,7 +53,7 @@ RetiTexture::RetiTexture(string path)
     wrap_s = RETI_TEXWRAP_MIRROR;
     wrap_t = RETI_TEXWRAP_MIRROR;
     texture_unit = GL_TEXTURE0;
-    load_texture_from_file(RetiRenderer::getReticleRootDirectory() + path);
+    load_texture_from_file(path);
 }
 
 RetiTexture::RetiTexture(string path, RetiTextureFilterMode fmode, RetiMipmapFilterMode mmode,
@@ -66,7 +66,7 @@ RetiTexture::RetiTexture(string path, RetiTextureFilterMode fmode, RetiMipmapFil
     texture_unit = GL_TEXTURE0 + bind_location;
     if(bind_location > 15)
         RetiLog::logln("WARNING: Support for bind locations above 15 is platform dependent.");
-    load_texture_from_file(RetiRenderer::getReticleRootDirectory() + path);
+    load_texture_from_file(path);
 }
 
 RetiTexture::RetiTexture(const RetiTexture& other)


### PR DESCRIPTION
This PR is a short and simple fix for the [Black Chair Bug](https://github.com/CodeCancer/ProjectReticle/issues/14). 

### Cause of issue:

Looking at the log files, it was fairly simple to understand what was going wrong. Log excerpt:

    [23-07-2017 23:43:41]    Loading file: /mnt/data/git-repos/ProjectReticle/Reticle/home/digumx/Models/Chair/4_5_15_D.JPG
    [23-07-2017 23:43:41]    WARNING : Unable to load texture data, data is nullptr, segfault imminent.
    [23-07-2017 23:43:41]    Loading file: /mnt/data/git-repos/ProjectReticle/Reticle/home/digumx/Models/Chair/METAL 6.JPG
    [23-07-2017 23:43:41]    WARNING : Unable to load texture data, data is nullptr, segfault imminent

The above log excerpt shows that while attempting to load the .3DS file (at `/home/digumx/Models/Chair/Armchair.3DS`), it attempts to load it's linked texture image files from `/mnt/data/git-repos/ProjectReticle/Reticle/home/digumx/Models/Chair`. That obviously fails, because the textures are actually at `/home/digumx/Models/Chair/`. This causes null data to be loaded, which ultimately leads to a black texture.

It is not hard to notice that the filepath was being malformed because somehow, the Reticle Root Directory was being prepended to it. Following the trail of the filepath through function call, the problematic lines were found to be (currently) 56 and 69 in [RetiTexture.cpp](https://github.com/CodeCancer/ProjectReticle/blob/master/Reticle/Sources/RetiTexture.cpp):

    load_texture_from_file(RetiRenderer::getReticleRootDirectory() + path);

Just fixing those lines to:

    load_texture_from_file(path);

fixes the bug.

### Unanswered Questions:

**Two questions remain unanswered:**

 -  How did such a mistake happen in the first place?
 -  How had the bug escaped detection until now?
 -  If the bug had been in earlier versions, how did those versions load textured assets correctly?

**Plausible answers:**

 -  Probably lines 56 and 69 were mixed up somehow with line 46 in [RetiTexture.cpp](https://github.com/CodeCancer/ProjectReticle/blob/master/Reticle/Sources/RetiTexture.cpp). See note below.
 -  Probably it had not, and was fixed at a very early stage. Read point below.
 -  Probably this bug had been detected and fixed by a local commit when working on the assimp update. However, mis-merging issues from merging the keyboard input and assimp updates at the same time caused  this bug to crop back up. I had attempted to dissect to confirm this, however the mis-merging had caused considerable graph scrambling, making this an unreasonably difficult task, especially considering the fact that the bug seems fixed.

### Note:

Line number 46 in [RetiTexture.cpp](https://github.com/CodeCancer/ProjectReticle/blob/master/Reticle/Sources/RetiTexture.cpp) is correct. Prepending the reticle root rirectory here makes sense since the reticle default texture (which is what the default constructor for `RetiTexture` loads in line 46) resides in the reticle root directory. 